### PR TITLE
Key value client class and minor changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,5 @@ set (KV_DIR "src/key_value")
 add_executable(key_value_test ${KV_DIR}/key_value_test.cc ${KV_DIR}/key_value.cc)
 target_link_libraries(key_value_test gtest_main glog::glog)
 
-add_executable(key_value_run ${KV_DIR}/key_value_run.cc ${KV_DIR}/key_value_server.cc ${KV_DIR}/key_value.cc ${kv_proto_srcs} ${kv_grpc_srcs})
-target_link_libraries(key_value_run ${_GRPC_GRPCPP} ${_PROTOBUF_LIBPROTOBUF} glog::glog)
-
+add_executable(key_value_server ${KV_DIR}/key_value_run.cc ${KV_DIR}/key_value_server.cc ${KV_DIR}/key_value.cc ${kv_proto_srcs} ${kv_grpc_srcs})
+target_link_libraries(key_value_server ${_GRPC_GRPCPP} ${_PROTOBUF_LIBPROTOBUF} glog::glog)

--- a/src/key_value/key_value.cc
+++ b/src/key_value/key_value.cc
@@ -12,11 +12,11 @@ void KeyValue::Put(const std::string& key, const std::string& value) {
   auto storage_iter = storage_.find(key);
   if (storage_iter != storage_.end()) {
     storage_iter->second.push_back(value);
-    LOG(INFO) << "appended value to list for key" << "\n";
+    LOG(INFO) << "appended value to list for key";
   } else {
     std::vector<std::string> value_list{value};
     storage_[key] = value_list;
-    LOG(INFO) << "stored new key value pair" << "\n";
+    LOG(INFO) << "stored new key value pair";
   }
   lock_.unlock();
 }
@@ -26,11 +26,11 @@ std::vector<std::string> KeyValue::Get(const std::string& key) {
   auto storage_iter = storage_.find(key);
   if (storage_iter != storage_.end()) {
     lock_.unlock();
-    LOG(INFO) << "found value(s) for key " << key << "\n";
+    LOG(INFO) << "found value(s) for key " << key;
     return storage_iter->second;
   }
   lock_.unlock();
-  LOG(WARNING) << "could not find values for key  " << key << "\n";
+  LOG(WARNING) << "could not find values for key  " << key;
   return {};
 }
 
@@ -38,7 +38,7 @@ void KeyValue::Remove(const std::string& key) {
   lock_.lock();
   storage_.erase(key);
   lock_.unlock();
-  LOG(INFO) << "removed any existing values for key " << key << "\n";
+  LOG(INFO) << "removed any existing values for key " << key;
 }
 
 }  // namespace csci499

--- a/src/key_value/key_value_client.cc
+++ b/src/key_value/key_value_client.cc
@@ -1,0 +1,75 @@
+// Copyright (c) 2021, USC
+// All rights reserved.
+
+#include "key_value_client.h"
+
+#include <glog/logging.h>
+
+namespace csci499 {
+using grpc::ClientContext;
+using grpc::ClientReaderWriter;
+using grpc::Status;
+
+using kvstore::GetReply;
+using kvstore::GetRequest;
+using kvstore::KeyValueStore;
+using kvstore::PutReply;
+using kvstore::PutRequest;
+using kvstore::RemoveReply;
+using kvstore::RemoveRequest;
+
+void KeyValueClient::Put(const std::string& key, const std::string& value) {
+  PutRequest request;
+  request.set_key(key);
+  request.set_value(value);
+
+  PutReply reply;
+  ClientContext context;
+  Status status = stub_->put(&context, request, &reply);
+  if (status.ok()) {
+    LOG(INFO) << "Put request successful from client for key " << key;
+  } else {
+    LOG(WARNING) << "Put request failed from client for key " << key;
+  }
+}
+
+std::vector<std::string> KeyValueClient::Get(const std::string& key) {
+  GetRequest request;
+  request.set_key(key);
+  ClientContext context;
+  std::shared_ptr<ClientReaderWriter<GetRequest, GetReply> > stream(
+      stub_->get(&context));
+  stream->Write(request);
+  stream->WritesDone();
+
+  GetReply reply;
+  std::vector<std::string> values;
+  while (stream->Read(&reply)) {
+    values.push_back(reply.value());
+    LOG(INFO) << "Get request value returned: " << reply.value();
+  }
+  Status status = stream->Finish();
+  if (status.ok()) {
+    LOG(INFO) << "Get request successful from client for key " << key;
+    return values;
+  } else {
+    LOG(WARNING) << "Get request failed from client for key " << key;
+    return {};
+  }
+}
+
+void KeyValueClient::Remove(const std::string& key) {
+  RemoveRequest request;
+  request.set_key(key);
+
+  RemoveReply reply;
+  ClientContext context;
+  Status status = stub_->remove(&context, request, &reply);
+  if (status.ok()) {
+    LOG(INFO) << "Remove request successful from client for key " << key;
+  } else {
+    LOG(WARNING) << "Remove request failed from client for key " << key;
+  }
+}
+
+}  // namespace csci499

--- a/src/key_value/key_value_client.cc
+++ b/src/key_value/key_value_client.cc
@@ -18,7 +18,7 @@ using kvstore::PutRequest;
 using kvstore::RemoveReply;
 using kvstore::RemoveRequest;
 
-void KeyValueClient::Put(const std::string& key, const std::string& value) {
+bool KeyValueClient::Put(const std::string& key, const std::string& value) {
   PutRequest request;
   request.set_key(key);
   request.set_value(value);
@@ -31,6 +31,7 @@ void KeyValueClient::Put(const std::string& key, const std::string& value) {
   } else {
     LOG(WARNING) << "Put request failed from client for key " << key;
   }
+  return status.ok();
 }
 
 std::vector<std::string> KeyValueClient::Get(const std::string& key) {

--- a/src/key_value/key_value_client.h
+++ b/src/key_value/key_value_client.h
@@ -24,10 +24,10 @@ class KeyValueClient {
   explicit KeyValueClient(std::shared_ptr<Channel> channel)
       : stub_(KeyValueStore::NewStub(channel)) {}
 
-  ~KeyValueClient() {}
+  virtual ~KeyValueClient() {}
 
   // package and send rpc call put to server
-  void Put(const std::string& key, const std::string& value);
+  bool Put(const std::string& key, const std::string& value);
 
   // package and retrieve rpc call get from server
   std::vector<std::string> Get(const std::string& key);

--- a/src/key_value/key_value_client.h
+++ b/src/key_value/key_value_client.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2021, USC
+// All rights reserved.
+
+#ifndef SRC_KEY_VALUE_KEY_VALUE_CLIENT_H_
+#define SRC_KEY_VALUE_KEY_VALUE_CLIENT_H_
+
+#include <grpcpp/grpcpp.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "key_value.grpc.pb.h"
+
+
+namespace csci499 {
+using grpc::Channel;
+
+using kvstore::KeyValueStore;
+
+// key value client implementtaion for csci499
+class KeyValueClient {
+ public:
+  explicit KeyValueClient(std::shared_ptr<Channel> channel)
+      : stub_(KeyValueStore::NewStub(channel)) {}
+
+  ~KeyValueClient() {}
+
+  // package and send rpc call put to server
+  void Put(const std::string& key, const std::string& value);
+
+  // package and retrieve rpc call get from server
+  std::vector<std::string> Get(const std::string& key);
+
+  // rpc remove key and all values on server
+  void Remove(const std::string& key);
+
+ private:
+  // key value storage object
+  std::unique_ptr<KeyValueStore::Stub> stub_;
+};
+
+}  // namespace csci499
+#endif  // SRC_KEY_VALUE_KEY_VALUE_CLIENT_H_

--- a/src/key_value/key_value_run.cc
+++ b/src/key_value/key_value_run.cc
@@ -26,7 +26,7 @@ void RunServer() {
 
   // Assembling the server
   std::unique_ptr<Server> server(builder.BuildAndStart());
-  LOG(INFO) << "Server listening on port: " << server_address << "\n";
+  LOG(INFO) << "Server listening on port: " << server_address;
 
   server->Wait();
 }

--- a/src/key_value/key_value_server.cc
+++ b/src/key_value/key_value_server.cc
@@ -15,7 +15,7 @@ Status KeyValueServer::put(ServerContext* context, const PutRequest* request,
                            PutReply* reply) {
   storage_.Put(request->key(), request->value());
   LOG(INFO) << "rpc put key value pair " << request->key() << " "
-            << request->value() << "\n";
+            << request->value();
   return Status::OK;
 }
 
@@ -30,7 +30,7 @@ Status KeyValueServer::get(ServerContext* context,
     reply.set_value(v);
     stream->Write(reply);
   }
-  LOG(INFO) << "rpc get request on key " << key << "\n";
+  LOG(INFO) << "rpc get request on key " << key;
   return Status::OK;
 }
 
@@ -38,7 +38,7 @@ Status KeyValueServer::remove(ServerContext* context,
                               const RemoveRequest* request,
                               RemoveReply* reply) {
   storage_.Remove(request->key());
-  LOG(INFO) << "rpc removed key " << request->key() << "\n";
+  LOG(INFO) << "rpc removed key " << request->key();
   return Status::OK;
 }
 

--- a/src/key_value/key_value_server.h
+++ b/src/key_value/key_value_server.h
@@ -45,7 +45,6 @@ class KeyValueServer final : public KeyValueStore::Service {
  private:
   // key value storage object
   KeyValue storage_;
-  // lock for key value storeage object
 };
 
 }  // namespace csci499


### PR DESCRIPTION
This PR accomplishes 3 main tasks:
- deletes the explicit `<< "\n"` for Glog everywhere since Glog implicitly adds it
- modifies CMakeLists.txt to change the executable name for kv server from key_value_run to key_value_server
- Finally, adds the kv client class to interact with kv server