### PR TITLE
Finished Caw functions and Faz backend

### DIFF
--- a/src/caw/caw_function.cc
+++ b/src/caw/caw_function.cc
@@ -4,6 +4,8 @@
 #include "caw_function.h"
 
 #include <glog/logging.h>
+#include <sys/time.h>
+#include <unistd.h>
 
 #include <vector>
 
@@ -13,7 +15,7 @@ namespace csci499 {
 std::unordered_map<std::string,
                    std::function<CawFuncReply(const Any&, KeyValueInterface&)> >
     CawFunction::function_map_ = {{"registeruser", &CawFunction::RegisterUser},
-                                  {"caw", &CawFunction::Caw},
+                                  {"caw", &CawFunction::CawCreate},
                                   {"follow", &CawFunction::Follow},
                                   {"read", &CawFunction::Read},
                                   {"profile", &CawFunction::Profile}};
@@ -36,9 +38,43 @@ CawFuncReply CawFunction::RegisterUser(const Any& payload,
   return {Status(StatusCode::OK, "successfully registered user " + username)};
 }
 
-CawFuncReply CawFunction::Caw(const Any& payload, KeyValueInterface& kv) {
-  // wait for prof email
-  return {Status::OK};
+CawFuncReply CawFunction::CawCreate(const Any& payload, KeyValueInterface& kv) {
+  CawRequest request;
+  payload.UnpackTo(&request);
+  std::string username = request.username();
+  std::string text = request.text();
+  std::string parent_id = request.parent_id();
+  std::vector<std::string> prev_caws = kv.Get("caws");
+  // the caw id for the current caw is the previous count of all caws before it
+  std::string caw_id = std::to_string(prev_caws.size());
+  if (!UserExists(username, kv)) {
+    LOG(WARNING) << "the user does not exist";
+    return {Status(StatusCode::UNAVAILABLE, "the user does not exist")};
+  } else if (!parent_id.empty()) {
+    if (std::find(prev_caws.begin(), prev_caws.end(), parent_id) ==
+        prev_caws.end()) {
+      LOG(WARNING) << "the parent caw does not exist";
+      return {Status(StatusCode::UNAVAILABLE, "the parent caw does not exist")};
+    } else {
+      // store all children ids of a Caw in a key cawchildren-<parent-id>
+      kv.Put("cawchildren-" + parent_id, caw_id);
+    }
+  }
+  kv.Put("caws", caw_id);
+  timeval curr_time;
+  gettimeofday(&curr_time, NULL);
+  Timestamp time;
+  time.set_seconds(curr_time.tv_sec);
+  time.set_useconds(curr_time.tv_usec);
+  Caw caw;  // create caw message
+  caw.set_username(username);
+  caw.set_text(text);
+  caw.set_id(caw_id);
+  caw.set_parent_id(parent_id);
+  caw.mutable_timestamp()->CopyFrom(time);
+  // store serialized caw in key caw-<caw-id>
+  kv.Put("caw-" + caw_id, caw.SerializeAsString());
+  return {Status::OK, caw.SerializeAsString()};
 }
 
 CawFuncReply CawFunction::Follow(const Any& payload, KeyValueInterface& kv) {
@@ -71,8 +107,23 @@ CawFuncReply CawFunction::Follow(const Any& payload, KeyValueInterface& kv) {
 }
 
 CawFuncReply CawFunction::Read(const Any& payload, KeyValueInterface& kv) {
-  // wait for prof email
-  return {Status::OK};
+  ReadRequest request;
+  payload.UnpackTo(&request);
+  std::string caw_id = request.caw_id();
+  std::vector<std::string> caws = kv.Get("caws");
+  if (std::find(caws.begin(), caws.end(), caw_id) == caws.end()) {
+    LOG(WARNING) << "the caw does not exist";
+    return {Status(StatusCode::UNAVAILABLE, "the caw does not exist")};
+  }
+  std::vector<Caw> caw_replys;
+  // recursively find all children/replys to caw_id
+  ReadReplys(caw_id, kv, caw_replys);
+  ReadReply reply;
+  for (int i = 0; i < caw_replys.size(); ++i) {
+    Caw* c = reply.add_caws();
+    c->CopyFrom(caw_replys[i]);
+  }
+  return {Status::OK, reply.SerializeAsString()};
 }
 
 CawFuncReply CawFunction::Profile(const Any& payload, KeyValueInterface& kv) {
@@ -86,10 +137,10 @@ CawFuncReply CawFunction::Profile(const Any& payload, KeyValueInterface& kv) {
   std::vector<std::string> followers = kv.Get("ufollowers-" + username);
   std::vector<std::string> following = kv.Get("ufollowing-" + username);
   ProfileReply reply;
-  for (auto f : followers) {
+  for (const auto& f : followers) {
     reply.add_followers(f);
   }
-  for (auto f : following) {
+  for (const auto& f : following) {
     reply.add_following(f);
   }
   return {Status::OK, reply.SerializeAsString()};
@@ -99,6 +150,17 @@ bool CawFunction::UserExists(const std::string& username,
                              KeyValueInterface& kv) {
   std::vector<std::string> users = kv.Get("users");
   return std::find(users.begin(), users.end(), username) != users.end();
+}
+
+void CawFunction::ReadReplys(const std::string& caw_id, KeyValueInterface& kv,
+                             std::vector<Caw>& caws) {
+  Caw caw;
+  caw.ParseFromString(kv.Get("caw-" + caw_id)[0]);
+  caws.push_back(caw);
+  std::vector<std::string> children = kv.Get("cawchildren-" + caw_id);
+  for (const auto& c : children) {
+    ReadReplys(c, kv, caws);
+  }
 }
 
 }  // namespace csci499

--- a/src/caw/caw_function.h
+++ b/src/caw/caw_function.h
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "../key_value/key_value_interface.h"
 #include "caw.grpc.pb.h"
@@ -18,6 +19,7 @@ using google::protobuf::Any;
 using grpc::Status;
 using grpc::StatusCode;
 
+using caw::Caw;
 using caw::CawReply;
 using caw::CawRequest;
 using caw::FollowReply;
@@ -28,6 +30,7 @@ using caw::ReadReply;
 using caw::ReadRequest;
 using caw::RegisteruserReply;
 using caw::RegisteruserRequest;
+using caw::Timestamp;
 
 // struct for caw function reply message
 struct CawFuncReply {
@@ -41,7 +44,7 @@ class CawFunction {
   static CawFuncReply RegisterUser(const Any& payload, KeyValueInterface& kv);
 
   // creates new caw
-  static CawFuncReply Caw(const Any& payload, KeyValueInterface& kv);
+  static CawFuncReply CawCreate(const Any& payload, KeyValueInterface& kv);
 
   // follows another user
   static CawFuncReply Follow(const Any& payload, KeyValueInterface& kv);
@@ -60,6 +63,9 @@ class CawFunction {
  private:
   // check if user exists
   static bool UserExists(const std::string& username, KeyValueInterface& kv);
+  // DFS recursively search for all child Caws and add to caws vector
+  static void ReadReplys(const std::string& caw_id, KeyValueInterface& kv,
+                         std::vector<Caw>& caws);
 };
 }  // namespace csci499
 #endif  // SRC_CAW_CAW_FUNCTION_H_

--- a/src/faz/faz_client.cc
+++ b/src/faz/faz_client.cc
@@ -1,0 +1,56 @@
+// Copyright (c) 2021, USC
+// All rights reserved.
+
+#include "faz_client.h"
+
+#include "glog/logging.h"
+
+namespace csci499 {
+
+bool FazClient::Hook(int event_type, const std::string& event_function) {
+  HookRequest request;
+  request.set_event_type(event_type);
+  request.set_event_function(event_function);
+
+  ClientContext context;
+  HookReply reply;
+  Status status = stub_->hook(&context, request, &reply);
+
+  if (status.ok()) {
+    LOG(INFO) << "client call to hook function" << event_function
+              << "with type:" << event_type;
+    return true;
+  } else {
+    LOG(WARNING) << "error in client hook call: " << status.error_code();
+    return false;
+  }
+}  // namespace csci499
+
+bool FazClient::Unhook(int event_type) {
+  UnhookRequest request;
+  request.set_event_type(event_type);
+
+  ClientContext context;
+  UnhookReply reply;
+  Status status = stub_->unhook(&context, request, &reply);
+
+  if (status.ok()) {
+    LOG(INFO) << "client call to unhook event type:" << event_type;
+    return true;
+  } else {
+    LOG(WARNING) << "error in client unhook call: " << status.error_code();
+    return false;
+  }
+}
+
+Status FazClient::Event(int event_type, Any& payload, EventReply& reply) {
+  EventRequest request;
+  request.set_event_type(event_type);
+  request.set_allocated_payload(&payload);
+
+  ClientContext context;
+  Status status = stub_->event(&context, request, &reply);
+  return status;
+}
+
+}  // namespace csci499

--- a/src/faz/faz_client.h
+++ b/src/faz/faz_client.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2021, USC
+// All rights reserved.
+
+#ifndef SRC_FAZ_FAZ_CLIENT_H_
+#define SRC_FAZ_FAZ_CLIENT_H_
+
+#include <grpcpp/grpcpp.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <ostream>
+
+#include "caw.grpc.pb.h"
+#include "faz.grpc.pb.h"
+
+namespace csci499 {
+
+using faz::FazService;
+
+using google::protobuf::Any;
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Status;
+using grpc::StatusCode;
+
+using faz::EventReply;
+using faz::EventRequest;
+using faz::FazService;
+using faz::HookReply;
+using faz::HookRequest;
+using faz::UnhookReply;
+using faz::UnhookRequest;
+
+using caw::Caw;
+using caw::CawReply;
+using caw::CawRequest;
+using caw::FollowReply;
+using caw::FollowRequest;
+using caw::ProfileReply;
+using caw::ProfileRequest;
+using caw::ReadReply;
+using caw::ReadRequest;
+using caw::RegisteruserReply;
+using caw::RegisteruserRequest;
+using caw::Timestamp;
+
+// faz client implementaion for interacting with faz server
+class FazClient {
+ public:
+  explicit FazClient(std::shared_ptr<Channel> channel)
+      : stub_(FazService::NewStub(channel)) {}
+
+  virtual ~FazClient() {}
+
+  // hook function on faz server
+  bool Hook(int event_type, const std::string& event_function);
+
+  // unhook a function on faz server
+  bool Unhook(int event_type);
+
+  // send an event request to faz server and return proto Reply object
+  Status Event(int event_type, Any& payload, EventReply& reply);
+ private:
+  // faz storage object
+  std::unique_ptr<FazService::Stub> stub_;
+};
+
+}  // namespace csci499
+#endif  // SRC_FAZ_FAZ_CLIENT_H_

--- a/src/faz/faz_server.cc
+++ b/src/faz/faz_server.cc
@@ -44,7 +44,7 @@ Status FazServer::event(ServerContext* context, const EventRequest* request,
     LOG(WARNING) << "event is unhooked for event type " << event_type;
     return Status(StatusCode::NOT_FOUND, "event in not hooked");
   } else {
-    event_function = get_event[get_event.size() - 1];
+    event_function = get_event.back();
   }
 
   auto caw_method = CawFunction::function_map_[event_function];

--- a/src/faz/faz_server.cc
+++ b/src/faz/faz_server.cc
@@ -44,7 +44,7 @@ Status FazServer::event(ServerContext* context, const EventRequest* request,
     LOG(WARNING) << "event is unhooked for event type " << event_type;
     return Status(StatusCode::NOT_FOUND, "event in not hooked");
   } else {
-    event_function = get_event[0];
+    event_function = get_event[get_event.size() - 1];
   }
 
   auto caw_method = CawFunction::function_map_[event_function];


### PR DESCRIPTION
Here is the overview of this PR:
- added Caw functions `Caw` and `Read` for Faz to call on the backend
- added tests for `Caw` and `Read`
- added Faz client for CLI to interact with.  Sidenote:  I tried to abstract the calls to hook and unhook to keep the functionality simple for the frontend to handle, but then for event calls the frontend will handle status and payload completely.

Edit: The function name to create a caw is `CawCreate` instead of `Caw` since it got confusing working with the GPRC Caw object and function Caw in the CawFunctions class.