### PR TITLE
KV Storage - Persistent File Storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,25 @@ add_custom_command(
         "${caw_proto}"
       DEPENDS "${caw_proto}")
 
+# kv persist proto setup
+get_filename_component(kv_persist_proto "protos/kv_persist.proto" ABSOLUTE)
+get_filename_component(kv_persist_proto_path "${kv_persist_proto}" PATH)
+# generated files
+set(kv_persist_proto_srcs "${CMAKE_CURRENT_BINARY_DIR}/kv_persist.pb.cc")
+set(kv_persist_proto_hdrs "${CMAKE_CURRENT_BINARY_DIR}/kv_persist.pb.h")
+set(kv_persist_grpc_srcs "${CMAKE_CURRENT_BINARY_DIR}/kv_persist.grpc.pb.cc")
+set(kv_persist_grpc_hdrs "${CMAKE_CURRENT_BINARY_DIR}/kv_persist.grpc.pb.h")
+add_custom_command(
+      OUTPUT "${kv_persist_proto_srcs}" "${kv_persist_proto_hdrs}" "${kv_persist_grpc_srcs}" "${kv_persist_grpc_hdrs}"
+      COMMAND ${_PROTOBUF_PROTOC}
+      ARGS --grpc_out "${CMAKE_CURRENT_BINARY_DIR}"
+        --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
+        -I "${kv_persist_proto_path}"
+        -I "${CMAKE_CURRENT_BINARY_DIR}/_deps/grpc-src/third_party/protobuf/src"
+        --plugin=protoc-gen-grpc="${_GRPC_CPP_PLUGIN_EXECUTABLE}"
+        "${kv_persist_proto}"
+      DEPENDS "${kv_persist_proto}")
+
 # Include generated *.pb.h files
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
@@ -109,11 +128,11 @@ set (KV_DIR "src/key_value")
 set (FAZ_DIR "src/faz")
 set (CAW_DIR "src/caw")
 
-add_executable(key_value_test ${KV_DIR}/key_value_test.cc ${KV_DIR}/key_value.cc)
+add_executable(key_value_test ${KV_DIR}/key_value_test.cc ${KV_DIR}/key_value.cc ${kv_persist_proto_srcs})
 target_link_libraries(key_value_test gtest_main glog::glog)
 
-add_executable(key_value_server ${KV_DIR}/key_value_run.cc ${KV_DIR}/key_value_server.cc ${KV_DIR}/key_value.cc ${kv_proto_srcs} ${kv_grpc_srcs})
-target_link_libraries(key_value_server ${_GRPC_GRPCPP} ${_PROTOBUF_LIBPROTOBUF} glog::glog)
+add_executable(key_value_server ${KV_DIR}/key_value_run.cc ${KV_DIR}/key_value_server.cc ${KV_DIR}/key_value.cc ${kv_proto_srcs} ${kv_grpc_srcs} ${kv_persist_proto_srcs})
+target_link_libraries(key_value_server ${_GRPC_GRPCPP} ${_PROTOBUF_LIBPROTOBUF} glog::glog gflags )
 
 add_executable(faz_server ${FAZ_DIR}/faz_run.cc ${FAZ_DIR}/faz_server.cc ${FAZ_DIR}/faz_client.cc ${CAW_DIR}/caw_function.cc ${KV_DIR}/key_value_client.cc ${kv_proto_srcs} ${kv_grpc_srcs} ${faz_proto_srcs} ${faz_grpc_srcs} ${caw_proto_srcs} ${caw_grpc_srcs})
 target_link_libraries(faz_server ${_GRPC_GRPCPP} ${_PROTOBUF_LIBPROTOBUF} glog::glog gflags)

--- a/protos/kv_persist.proto
+++ b/protos/kv_persist.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package kvstore;
+
+// kv pair for serializable persistant storage
+message KeyValuePair {
+  bytes key = 1;
+  repeated bytes values = 2;
+}
+
+// kv message which stores a snapshot of the database since only one
+// protobuf object can be stored in a file
+message KeyValueSnapshot {
+  repeated KeyValuePair pairs = 1;
+}

--- a/src/key_value/key_value.h
+++ b/src/key_value/key_value.h
@@ -10,8 +10,11 @@
 #include <vector>
 
 #include "key_value_interface.h"
+#include "kv_persist.grpc.pb.h"
 
 namespace csci499 {
+using kvstore::KeyValuePair;
+using kvstore::KeyValueSnapshot;
 
 // key value storage for csci499 application
 class KeyValue : public KeyValueInterface {
@@ -25,6 +28,12 @@ class KeyValue : public KeyValueInterface {
   std::vector<std::string> Get(const std::string& key) override;
 
   void Remove(const std::string& key) override;
+
+  // stores snapshot of current kv state in snapshot parameter
+  void TakeSnapshot(KeyValueSnapshot& snapshot);
+
+  // loads current snapshot of kv state from provided snapshot
+  void LoadSnapshot(KeyValueSnapshot& snapshot);
 
  private:
   // stores key value pairs in map of vectors

--- a/src/key_value/key_value_run.cc
+++ b/src/key_value/key_value_run.cc
@@ -1,11 +1,14 @@
 // Copyright (c) 2021, USC
 // All rights reserved.
 
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include <string>
 
 #include "key_value_server.h"
+
+DEFINE_string(store, "", "loads and stores key value service in provided file");
 
 namespace csci499 {
 
@@ -17,23 +20,31 @@ using grpc::Status;
 
 void RunKVServer() {
   std::string server_address("0.0.0.0:50001");
-  KeyValueServer service;
+  KeyValueServer* service;
 
   // listen on port 50001 with insecure credititals
   ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-  builder.RegisterService(&service);
+  if (FLAGS_store.empty()) {
+    service = new KeyValueServer();
+  } else {
+    service = new KeyValueServer(FLAGS_store);
+  }
+  builder.RegisterService(service);
 
   // Assembling the server
   std::unique_ptr<Server> server(builder.BuildAndStart());
   LOG(INFO) << "Server listening on port: " << server_address;
 
   server->Wait();
+
+  delete service;
 }
 
 }  // namespace csci499
 
 int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
   google::InitGoogleLogging(argv[0]);
 
   csci499::RunKVServer();

--- a/src/key_value/key_value_server.cc
+++ b/src/key_value/key_value_server.cc
@@ -6,21 +6,37 @@
 #include <glog/logging.h>
 
 #include <cstdio>
+#include <fstream>
+#include <iostream>
 #include <string>
 #include <vector>
 
 namespace csci499 {
+
+KeyValueServer::KeyValueServer() : storage_(), storage_file_() {}
+
+KeyValueServer::KeyValueServer(std::string filename)
+    : storage_(), storage_file_(filename) {
+  std::ifstream input(storage_file_);
+  if (input.is_open()) {  // read file if exists and store in snapshot
+    KeyValueSnapshot snapshot;
+    snapshot.ParseFromIstream(&input);
+    storage_.LoadSnapshot(snapshot);
+  }
+  input.close();
+}
 
 Status KeyValueServer::put(ServerContext* context, const PutRequest* request,
                            PutReply* reply) {
   storage_.Put(request->key(), request->value());
   LOG(INFO) << "rpc put key value pair " << request->key() << " "
             << request->value();
+  StoreSnapshot(storage_file_);
   return Status::OK;
 }
 
 Status KeyValueServer::get(ServerContext* context,
-           ServerReaderWriter<GetReply, GetRequest>* stream) {
+                           ServerReaderWriter<GetReply, GetRequest>* stream) {
   GetRequest request;
   stream->Read(&request);  // retrieve only the first request from the stream
   std::string key = request.key();
@@ -39,7 +55,25 @@ Status KeyValueServer::remove(ServerContext* context,
                               RemoveReply* reply) {
   storage_.Remove(request->key());
   LOG(INFO) << "rpc removed key " << request->key();
+  StoreSnapshot(storage_file_);
   return Status::OK;
+}
+
+bool KeyValueServer::StoreSnapshot(const std::string filename) {
+  if (!filename.empty()) {
+    KeyValueSnapshot snapshot;
+    storage_.TakeSnapshot(snapshot);  // get snapshot of DB from kv storage
+    std::ofstream output;
+    output.open(filename);
+    if (output.is_open() && snapshot.SerializeToOstream(&output)) {
+      LOG(INFO) << "stored kv snapshot to file";
+      output.close();
+    }
+    return true;
+  } else {
+    LOG(WARNING) << "There was an error storing or serializing the current kv";
+    return false;
+  }
 }
 
 }  // namespace csci499

--- a/src/key_value/key_value_server.h
+++ b/src/key_value/key_value_server.h
@@ -6,8 +6,11 @@
 
 #include <grpcpp/grpcpp.h>
 
+#include <string>
+
 #include "key_value.grpc.pb.h"
 #include "key_value.h"
+#include "kv_persist.grpc.pb.h"
 
 namespace csci499 {
 
@@ -19,18 +22,24 @@ using grpc::Status;
 
 using kvstore::GetReply;
 using kvstore::GetRequest;
+using kvstore::KeyValuePair;
 using kvstore::KeyValueStore;
 using kvstore::PutReply;
 using kvstore::PutRequest;
 using kvstore::RemoveReply;
 using kvstore::RemoveRequest;
+using kvstore::KeyValueSnapshot;
 
 // key value server implementtaion for csci499
 class KeyValueServer final : public KeyValueStore::Service {
  public:
-  KeyValueServer() : storage_() {}
+  // default constructor
+  KeyValueServer();
 
-  // grpc put call
+  // constructor for persistent file storage
+  KeyValueServer(std::string filename);
+
+  // grpc put call and store data in storage file if persistent kv
   Status put(ServerContext* context, const PutRequest* request,
              PutReply* reply) override;
 
@@ -38,13 +47,18 @@ class KeyValueServer final : public KeyValueStore::Service {
   Status get(ServerContext* context,
              ServerReaderWriter<GetReply, GetRequest>* stream) override;
 
-  // grpc remove call
+  // grpc remove call and remove all data in storage file if persistent kv
   Status remove(ServerContext* context, const RemoveRequest* request,
                 RemoveReply* reply) override;
 
  private:
+  // stores snapshot of current KeyValue Object in provided file
+  bool StoreSnapshot(const std::string filename);
+
   // key value storage object
   KeyValue storage_;
+  // file for persistent storage (empty string if no persistent)
+  std::string storage_file_;
 };
 
 }  // namespace csci499


### PR DESCRIPTION
Hi Fayez, thank you for reviewing this PR and let me know if you have any questions.  To create persistent file storage, I added a new proto `kv_persist.proto` as a way I can serialize snapshots of the current kv state.  Quick note: I found out in order to use `SerializeToOstream(ostream* output)` and `ParseFromIstream(istream* input)` there can only be one protobuf object in the file.  Therefore, I could not just store a list of serialized `KeyValuePair` objects.  Also, the functionality for loading and taking a snapshot of the database has been implemented in the `KeyValue` class to mimic how a database would load or take snapshots.  The `KeyValueServer` class mainly just calls the functions found in `KeyValue` to facilitate the transactions of database snapshots.  Finally, the last changes were in `CMakeLists.txt` where I added the new compilation of the `kv_persist.proto` protobuf.