### PR TITLE
Faz Layer Implementation

### DIFF
--- a/src/caw/caw.cc
+++ b/src/caw/caw.cc
@@ -238,8 +238,7 @@ int main(int argc, char* argv[]) {
       std::cout << std::endl;
     }
   } else if (command == input::kStream) {
-    // Pack Stream Request and pass into Faz client
-    // Take care of displaying output to terminal
+    // Since we will have to print multiple
   }
   return 0;
 }

--- a/src/caw/caw_function.cc
+++ b/src/caw/caw_function.cc
@@ -21,10 +21,10 @@ std::unordered_map<std::string,
                                   {"profile", &CawFunction::Profile}};
                                   
 std::unordered_map<std::string, std::function<CawFuncReply(const Any&,
-                                              KeyValueInterface&,
-                                              const std::function<void(const Any&)>&)> 
-                                              >
-    CawFunction::stream_function_map_ = {{"stream", &CawFunction::Stream}};
+                                              const std::unordered_map<std::string, 
+                                                std::vector<std::function<
+                                                  void(const Any&)>> >&)
+                  > > CawFunction::stream_function_map_ = {{"stream", &CawFunction::Stream}};
 
 CawFuncReply CawFunction::RegisterUser(const Any& payload,
                                        KeyValueInterface& kv) {
@@ -155,9 +155,10 @@ CawFuncReply CawFunction::Profile(const Any& payload, KeyValueInterface& kv) {
   return {Status::OK, reply.SerializeAsString()};
 }
 
-CawFuncReply CawFunction::Stream(const Any& payload, KeyValueInterface& kv,
-                                  const std::function<void(const Any&)>& 
-                                    writeToServerWriter) {
+CawFuncReply CawFunction::Stream(const Any& payload,
+                                  const std::unordered_map<std::string, 
+                                    std::vector<std::function<void(const Any&)>> >&
+                                  current_streamers_) {
   // This function will have a callback that has the server instance
   // It will store that function in the kvstore and call it whenever 
   // a matching tag is PUT in the kvstore. 

--- a/src/caw/caw_function.cc
+++ b/src/caw/caw_function.cc
@@ -156,7 +156,7 @@ CawFuncReply CawFunction::Profile(const Any& payload, KeyValueInterface& kv) {
 }
 
 CawFuncReply CawFunction::Stream(const Any& payload,
-                                  const std::unordered_map<std::string, 
+                                  std::unordered_map<std::string, 
                                     std::vector<std::function<void(const Any&)>> >&
                                   current_streamers_) {
   // This function will parse the payload and look for any hashtags 
@@ -182,7 +182,7 @@ void CawFunction::ReadReplys(const std::string& caw_id, KeyValueInterface& kv,
   }
 }
 
-std::vector<std::string> GetHashtags(const std::string& key) {
+std::vector<std::string> GetHashtags(const std::string& message) {
   // I will pass a caw text and find tags here
   return {};
 }

--- a/src/caw/caw_function.cc
+++ b/src/caw/caw_function.cc
@@ -159,9 +159,9 @@ CawFuncReply CawFunction::Stream(const Any& payload,
                                   const std::unordered_map<std::string, 
                                     std::vector<std::function<void(const Any&)>> >&
                                   current_streamers_) {
-  // This function will have a callback that has the server instance
-  // It will store that function in the kvstore and call it whenever 
-  // a matching tag is PUT in the kvstore. 
+  // This function will parse the payload and look for any hashtags 
+  // It will then call the functions for that corresponding hashtag 
+  // Without ever interracting with the kvstore
   return {Status::OK, ""};
 }
 
@@ -180,6 +180,11 @@ void CawFunction::ReadReplys(const std::string& caw_id, KeyValueInterface& kv,
   for (const auto& c : children) {
     ReadReplys(c, kv, caws);
   }
+}
+
+std::vector<std::string> GetHashtags(const std::string& key) {
+  // I will pass a caw text and find tags here
+  return {};
 }
 
 }  // namespace csci499

--- a/src/caw/caw_function.cc
+++ b/src/caw/caw_function.cc
@@ -21,7 +21,7 @@ std::unordered_map<std::string,
                                   {"profile", &CawFunction::Profile}};
                                   
 std::unordered_map<std::string, std::function<CawFuncReply(const Any&,
-                                              const std::unordered_map<std::string, 
+                                              std::unordered_map<std::string, 
                                                 std::vector<std::function<
                                                   void(const Any&)>> >&)
                   > > CawFunction::stream_function_map_ = {{"stream", &CawFunction::Stream}};

--- a/src/caw/caw_function.cc
+++ b/src/caw/caw_function.cc
@@ -18,8 +18,13 @@ std::unordered_map<std::string,
                                   {"caw", &CawFunction::CawCreate},
                                   {"follow", &CawFunction::Follow},
                                   {"read", &CawFunction::Read},
-                                  {"profile", &CawFunction::Profile},
-                                  {"stream", &CawFunction::Stream}};
+                                  {"profile", &CawFunction::Profile}};
+                                  
+std::unordered_map<std::string, std::function<CawFuncReply(const Any&,
+                                              KeyValueInterface&,
+                                              const std::function<void(const Any&)>&)> 
+                                              >
+    CawFunction::stream_function_map_ = {{"stream", &CawFunction::Stream}};
 
 CawFuncReply CawFunction::RegisterUser(const Any& payload,
                                        KeyValueInterface& kv) {
@@ -150,9 +155,12 @@ CawFuncReply CawFunction::Profile(const Any& payload, KeyValueInterface& kv) {
   return {Status::OK, reply.SerializeAsString()};
 }
 
-CawFuncReply CawFunction::Stream(const Any& payload, KeyValueInterface& kv) {
-  // This function interracts with the kvstore
-  // to accomplish streaming functionality
+CawFuncReply CawFunction::Stream(const Any& payload, KeyValueInterface& kv,
+                                  const std::function<void(const Any&)>& 
+                                    writeToServerWriter) {
+  // This function will have a callback that has the server instance
+  // It will store that function in the kvstore and call it whenever 
+  // a matching tag is PUT in the kvstore. 
   return {Status::OK, ""};
 }
 

--- a/src/caw/caw_function.h
+++ b/src/caw/caw_function.h
@@ -81,6 +81,8 @@ class CawFunction {
   // DFS recursively search for all child Caws and add to caws vector
   static void ReadReplys(const std::string& caw_id, KeyValueInterface& kv,
                          std::vector<Caw>& caws);
+  // Returns a vector containing all hashtags in some text.
+  std::vector<std::string> GetHashtags(const std::string& key);
 };
 }  // namespace csci499
 #endif  // SRC_CAW_CAW_FUNCTION_H_

--- a/src/caw/caw_function.h
+++ b/src/caw/caw_function.h
@@ -56,12 +56,22 @@ class CawFunction {
   static CawFuncReply Profile(const Any& payload, KeyValueInterface& kv);
 
   // TODO: WRITE FUNCTION DEFINITION WHEN COMPLETE
-  static CawFuncReply Stream(const Any& payload, KeyValueInterface& kv);
+  static CawFuncReply Stream(const Any& payload, KeyValueInterface& kv,
+                             const std::function<void(const Any&)>& 
+                              writeToServerWriter);
 
   // map names of functions to functions
   static std::unordered_map<
       std::string, std::function<CawFuncReply(const Any&, KeyValueInterface&)> >
       function_map_;
+
+  // map names of stream_functions to functions
+  // Seperate because stream_function declaration is different
+  static std::unordered_map<
+      std::string, std::function<CawFuncReply(const Any&,
+                                              KeyValueInterface&,
+                                              const std::function<void(const Any&)>&)> >
+      stream_function_map_;
 
  private:
   // check if user exists

--- a/src/caw/caw_function.h
+++ b/src/caw/caw_function.h
@@ -56,9 +56,10 @@ class CawFunction {
   static CawFuncReply Profile(const Any& payload, KeyValueInterface& kv);
 
   // TODO: WRITE FUNCTION DEFINITION WHEN COMPLETE
-  static CawFuncReply Stream(const Any& payload, KeyValueInterface& kv,
-                             const std::function<void(const Any&)>& 
-                              writeToServerWriter);
+  static CawFuncReply Stream(const Any& payload,
+                             const std::unordered_map<std::string, 
+                              std::vector<std::function<void(const Any&)>> >&
+                                current_streamers_);
 
   // map names of functions to functions
   static std::unordered_map<
@@ -69,9 +70,10 @@ class CawFunction {
   // Seperate because stream_function declaration is different
   static std::unordered_map<
       std::string, std::function<CawFuncReply(const Any&,
-                                              KeyValueInterface&,
-                                              const std::function<void(const Any&)>&)> >
-      stream_function_map_;
+                                              const std::unordered_map<std::string, 
+                                                std::vector<std::function<
+                                                  void(const Any&)>> >&)
+                                > > stream_function_map_;
 
  private:
   // check if user exists

--- a/src/caw/caw_function.h
+++ b/src/caw/caw_function.h
@@ -57,7 +57,7 @@ class CawFunction {
 
   // TODO: WRITE FUNCTION DEFINITION WHEN COMPLETE
   static CawFuncReply Stream(const Any& payload,
-                             const std::unordered_map<std::string, 
+                              std::unordered_map<std::string, 
                               std::vector<std::function<void(const Any&)>> >&
                                 current_streamers_);
 
@@ -71,7 +71,7 @@ class CawFunction {
   // TODO: Consider using a typedef
   static std::unordered_map<
       std::string, std::function<CawFuncReply(const Any&,
-                                              const std::unordered_map<std::string, 
+                                              std::unordered_map<std::string, 
                                                 std::vector<std::function<
                                                   void(const Any&)>> >&)
                                 > > stream_function_map_;

--- a/src/caw/caw_function.h
+++ b/src/caw/caw_function.h
@@ -68,6 +68,7 @@ class CawFunction {
 
   // map names of stream_functions to functions
   // Seperate because stream_function declaration is different
+  // TODO: Consider using a typedef
   static std::unordered_map<
       std::string, std::function<CawFuncReply(const Any&,
                                               const std::unordered_map<std::string, 
@@ -82,7 +83,7 @@ class CawFunction {
   static void ReadReplys(const std::string& caw_id, KeyValueInterface& kv,
                          std::vector<Caw>& caws);
   // Returns a vector containing all hashtags in some text.
-  std::vector<std::string> GetHashtags(const std::string& key);
+  std::vector<std::string> GetHashtags(const std::string& message);
 };
 }  // namespace csci499
 #endif  // SRC_CAW_CAW_FUNCTION_H_

--- a/src/faz/faz_client.cc
+++ b/src/faz/faz_client.cc
@@ -53,9 +53,23 @@ Status FazClient::Event(int event_type, Any& payload, EventReply& reply) {
   return status;
 }
 
-Status FazClient::Stream(int event_type, Any& payload, EventReply& reply) {
-  // Pack request and call server
-  return Status::OK;
+Status FazClient::Stream(int event_type, Any& payload,
+                          std::function<void(EventReply)>& print_caw) {
+  EventRequest request;
+  request.set_event_type(event_type);
+  *request.mutable_payload() = payload;
+
+  ClientContext context;
+  std::shared_ptr<ClientReader<EventReply> > readStream(
+      stub_->stream(&context, request));
+
+  EventReply reply; 
+
+  while (readStream->Read(&reply)) {
+    print_caw(reply);
+  }
+
+  return readStream->Finish();
 }
 
 }  // namespace csci499

--- a/src/faz/faz_client.h
+++ b/src/faz/faz_client.h
@@ -23,6 +23,7 @@ using grpc::Channel;
 using grpc::ClientContext;
 using grpc::Status;
 using grpc::StatusCode;
+using grpc::ClientReader;
 
 using faz::EventReply;
 using faz::EventRequest;
@@ -44,6 +45,8 @@ using caw::ReadRequest;
 using caw::RegisteruserReply;
 using caw::RegisteruserRequest;
 using caw::Timestamp;
+using caw::StreamRequest;
+using caw::StreamReply;
 
 // faz client implementaion for interacting with faz server
 class FazClient {
@@ -63,7 +66,8 @@ class FazClient {
   Status Event(int event_type, Any& payload, EventReply& reply);
 
   // TODO: WRITE FUNCTION DEFINITION WHEN COMPLETE
-  Status Stream(int event_type, Any& payload, EventReply& reply);
+  Status Stream(int event_type, Any& payload,
+                std::function<void(EventReply)>& print_caw);
  private:
   // faz storage object
   std::unique_ptr<FazService::Stub> stub_;

--- a/src/faz/faz_server.cc
+++ b/src/faz/faz_server.cc
@@ -58,6 +58,14 @@ Status FazServer::event(ServerContext* context, const EventRequest* request,
     CawReply reply;
     reply.ParseFromString(func_reply.message);
     any.PackFrom(reply);
+
+    // Here we will perform stream functionality
+    auto stream_method = CawFunction::stream_function_map_["stream"];
+    if (stream_method == nullptr) {
+      LOG(WARNING) << "not found in CawFunction class for function stream";
+      return Status(StatusCode::NOT_FOUND, "function call not found");
+    }
+    stream_method(any, current_streamers_);
   } else if (event_type == EventType::kFollow) {
     FollowReply reply;
     reply.ParseFromString(func_reply.message);
@@ -86,14 +94,7 @@ Status FazServer::stream(ServerContext* context, const EventRequest* request,
     return Status(StatusCode::NOT_FOUND, "event in not hooked");
   } else {
     event_function = get_event.back(); // Name of function "stream"
-  }
-
-  auto caw_method = CawFunction::stream_function_map_[event_function];
-  if (caw_method == nullptr) {
-    LOG(WARNING) << "not found in CawFunction class for function "
-                 << event_function;
-    return Status(StatusCode::NOT_FOUND, "function call not found");
-  }
+  } // Checking if stream function is hooked, will not use here
 
   // Creating a callback function that will write 
   // to THIS instance of a serverwriter
@@ -104,8 +105,17 @@ Status FazServer::stream(ServerContext* context, const EventRequest* request,
     writer->Write(reply);
   };
 
-  CawFuncReply func_reply = caw_method(request->payload(), kv_,
-                                        writeToServerWriter);
-  return func_reply.status;
+  StreamRequest streamRequest;
+  request->payload().UnpackTo(&streamRequest);
+
+  // Registering current ServerWriter as a streamer on our FazServer
+  // We will use the keyValue store to write messages to this streamer 
+  // Whenever a caw is posted. 
+  if (current_streamers_.find(streamRequest.hashtag()) == current_streamers_.end()) {
+    current_streamers_[streamRequest.hashtag()] = { writeToServerWriter };
+  } else { 
+    current_streamers_[streamRequest.hashtag()].push_back(writeToServerWriter);
+  }
+  return Status::OK;
 }
 }  // namespace csci499

--- a/src/faz/faz_server.h
+++ b/src/faz/faz_server.h
@@ -29,6 +29,7 @@ using faz::HookReply;
 using faz::HookRequest;
 using faz::UnhookReply;
 using faz::UnhookRequest;
+using caw::StreamRequest;
 
 class FazServer final : public FazService::Service {
  public:
@@ -55,6 +56,9 @@ class FazServer final : public FazService::Service {
  private:
   // key value client used to connect to kv server
   KeyValueClient kv_;
+
+  std::unordered_map<std::string, std::vector<std::function<void(const Any&)>> >
+    current_streamers_;
 };
 }  // namespace csci499
 #endif  // SRC_FAZ_FAZ_SERVER_H_

--- a/src/faz/faz_server.h
+++ b/src/faz/faz_server.h
@@ -56,7 +56,10 @@ class FazServer final : public FazService::Service {
  private:
   // key value client used to connect to kv server
   KeyValueClient kv_;
-
+  // This is a map that will store callback functions (value) for each 
+  // streamer with their associated hashtag (key)
+  // Each callback will have an instance of a writer which can be used to 
+  // send data back to the streamer
   std::unordered_map<std::string, std::vector<std::function<void(const Any&)>> >
     current_streamers_;
 };

--- a/src/key_value/key_value_client.cc
+++ b/src/key_value/key_value_client.cc
@@ -72,9 +72,4 @@ void KeyValueClient::Remove(const std::string& key) {
   }
 }
 
-std::vector<std::string> GetHashtags(const std::string& key) {
-  // I will pass a caw text and find tags here
-  return {};
-}
-
 }  // namespace csci499

--- a/src/key_value/key_value_client.h
+++ b/src/key_value/key_value_client.h
@@ -33,8 +33,6 @@ class KeyValueClient : public KeyValueInterface {
   void Remove(const std::string& key) override;
 
  private:
-  // Returns a vector containing all hashtags in some text.
-  std::vector<std::string> GetHashtags(const std::string& key);
 
   // key value storage object
   std::unique_ptr<KeyValueStore::Stub> stub_;


### PR DESCRIPTION
This PR covers implementation of the Faz Layer. 

My approach is as follows: 
- The streamers never need to interact with the kvstore because they only get data that is posted AFTER they make the stream request. 
- As such, I create a map with the key a string (the hashtag they are streaming) and callback functions that contain instances of the server writer. I store this in the FAZ SERVER. 
- Whenever a caw is posted, I pass the response (which is in the form of Any) into a stream function (defined in caw functions.h). Along with this response I pass in the map.

Whats left: 

- The stream function will parse the caw and retrieve all hashtags, then I will search the map for each hashtag and call the callback functions associated with the hashtag. This will be done in caw functions.h.
